### PR TITLE
Season and holiday configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Add `config.json` file in root directory with following content. You can use `co
   },
   "facebookAppId": "<facebook_id>", // optional facebook app link
   "assetsPath": "<path_to_graphics_assets>", // optional, for asset generation
+  "season": "spring", // optional, defaults to spring; season for all servers, seasons are "spring", "summer", "autumn" and "winter"
+  "holiday": "none", // optional, defaults to none; holiday for all servers, holidays are "none", "halloween", "christmas", "stpatricks" and "easter"
   "oauth": {
 		"google": {
 			"clientID": "<CLIENT_ID_HERE>",

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Add `config.json` file in root directory with following content. You can use `co
       "local": "localhost:8090",
       "name": "Dev server",
       "desc": "Development server",
+      "season": "summer", // optional, defaults to summer, seasons are "spring", "summer", "autumn" and "winter"
+      "holiday": "none", // optional, defaults to none, holidays are "none", "halloween", "christmas", "stpatricks" and "easter"
       "flag": "test", // optional flag ("test", "star" or space separated list of country flags)
       "flags": { // optional feature flags
         "test": true, // test server

--- a/config-template.json
+++ b/config-template.json
@@ -19,6 +19,8 @@
 		}
 	},
 	"assetsPath": "assets-source",
+	"season": "spring",
+	"holiday": "none",
 	"servers": [
 		{
 			"id": "test",
@@ -26,7 +28,7 @@
 			"path": "/s00/ws",
 			"local": "localhost:8090",
 			"name": "Test server",
-			"season": "summer",
+			"season": "spring",
 			"holiday": "none",
 			"desc": "Testing server",
 			"flags": {

--- a/config-template.json
+++ b/config-template.json
@@ -26,6 +26,8 @@
 			"path": "/s00/ws",
 			"local": "localhost:8090",
 			"name": "Test server",
+			"season": "summer",
+			"holiday": "none",
 			"desc": "Testing server",
 			"flags": {
 				"test": true

--- a/src/ts/common/adminInterfaces.ts
+++ b/src/ts/common/adminInterfaces.ts
@@ -150,6 +150,8 @@ export interface ServerConfig {
 	name: string;
 	desc: string;
 	flag: string;
+	season?: string;
+	holiday?: string;
 	host?: string;
 	alert?: string;
 	require?: string;

--- a/src/ts/common/constants.ts
+++ b/src/ts/common/constants.ts
@@ -1,6 +1,6 @@
 import { Season, Holiday } from './interfaces';
 
-export const SEASON: Season = Season.Autumn;
+export const SEASON: Season = Season.Spring;
 export const HOLIDAY: Holiday = Holiday.None;
 
 export const SECOND = 1000;

--- a/src/ts/common/utils.ts
+++ b/src/ts/common/utils.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { Point, Rect, Entity, Dict } from './interfaces';
+import { Point, Rect, Entity, Dict, Holiday, Season } from './interfaces';
 import { tileWidth, tileHeight, SECOND, MINUTE, HOUR, DAY } from './constants';
 import { ACCESS_ERROR, NOT_FOUND_ERROR, OFFLINE_ERROR, PROTECTION_ERROR } from './errors';
 
@@ -514,6 +514,29 @@ export function processCommand(text: string) {
 	const command = (space === -1 ? text : text.substr(0, space)).trim() as string | undefined;
 	const args = space === -1 ? '' : text.substr(space + 1).trim();
 	return { command, args };
+}
+
+export function parseSeason(value?: string): Season | undefined {
+	if (!value) return undefined;
+	switch (value.toLowerCase()) {
+		case 'spring': return Season.Spring;
+		case 'summer': return Season.Summer;
+		case 'autumn': return Season.Autumn;
+		case 'winter': return Season.Winter;
+		default: return undefined;
+	}
+}
+
+export function parseHoliday(value?: string): Holiday | undefined {
+	if (!value) return undefined;
+	switch (value.toLowerCase()) {
+		case 'none': return Holiday.None;
+		case 'halloween': return Holiday.Halloween;
+		case 'christmas': return Holiday.Christmas;
+		case 'stpatricks': return Holiday.StPatricks;
+		case 'easter': return Holiday.Easter;
+		default: return undefined;
+	}
 }
 
 // events

--- a/src/ts/server/commands.ts
+++ b/src/ts/server/commands.ts
@@ -1,6 +1,6 @@
 import { range, compact, escapeRegExp } from 'lodash';
 import {
-	MessageType, ChatType, Expression, Eye, Muzzle, Action, Season, Holiday, Weather, toAnnouncementMessageType,
+	MessageType, ChatType, Expression, Eye, Muzzle, Action, Weather, toAnnouncementMessageType,
 } from '../common/interfaces';
 import { hasRole } from '../common/accountUtils';
 import { butterfly, bat, firefly, cloud, getEntityType, getEntityTypeName } from '../common/entities';
@@ -17,7 +17,7 @@ import {
 	setEntityExpression, execAction, teleportTo
 } from './playerUtils';
 import { ServerLiveSettings, GameServerSettings } from '../common/adminInterfaces';
-import { isCommand, processCommand, clamp, flatten, includes, randomPoint } from '../common/utils';
+import { isCommand, processCommand, clamp, flatten, includes, randomPoint, parseSeason, parseHoliday } from '../common/utils';
 import { createNotifyUpdate, createShutdownServer } from './api/internal';
 import { logger } from './logger';
 import { pathTo } from './paths';
@@ -81,29 +81,6 @@ function adminModChat(names: string[], help: string, role: string, type: Message
 	return command(names, help, role, ({ }, client, message, _, __, settings) => {
 		sayToEveryone(client, message, filterBadWords(message), type, settings);
 	});
-}
-
-export function parseSeason(value?: string): Season | undefined {
-	if (!value) return undefined;
-	switch (value.toLowerCase()) {
-		case 'spring': return Season.Spring;
-		case 'summer': return Season.Summer;
-		case 'autumn': return Season.Autumn;
-		case 'winter': return Season.Winter;
-		default: return undefined;
-	}
-}
-
-export function parseHoliday(value?: string): Holiday | undefined {
-	if (!value) return undefined;
-	switch (value.toLowerCase()) {
-		case 'none': return Holiday.None;
-		case 'halloween': return Holiday.Halloween;
-		case 'christmas': return Holiday.Christmas;
-		case 'stpatricks': return Holiday.StPatricks;
-		case 'easter': return Holiday.Easter;
-		default: return undefined;
-	}
 }
 
 function parseWeather(value: string): Weather | undefined {

--- a/src/ts/server/commands.ts
+++ b/src/ts/server/commands.ts
@@ -100,6 +100,8 @@ export function parseHoliday(value?: string): Holiday | undefined {
 		case 'none': return Holiday.None;
 		case 'halloween': return Holiday.Halloween;
 		case 'christmas': return Holiday.Christmas;
+		case 'stpatricks': return Holiday.StPatricks;
+		case 'easter': return Holiday.Easter;
 		default: return undefined;
 	}
 }

--- a/src/ts/server/commands.ts
+++ b/src/ts/server/commands.ts
@@ -83,7 +83,8 @@ function adminModChat(names: string[], help: string, role: string, type: Message
 	});
 }
 
-function parseSeason(value: string): Season | undefined {
+export function parseSeason(value?: string): Season | undefined {
+    if (!value) return undefined;
 	switch (value.toLowerCase()) {
 		case 'spring': return Season.Spring;
 		case 'summer': return Season.Summer;
@@ -93,7 +94,8 @@ function parseSeason(value: string): Season | undefined {
 	}
 }
 
-function parseHoliday(value: string): Holiday | undefined {
+export function parseHoliday(value?: string): Holiday | undefined {
+    if (!value) return undefined;
 	switch (value.toLowerCase()) {
 		case 'none': return Holiday.None;
 		case 'halloween': return Holiday.Halloween;

--- a/src/ts/server/commands.ts
+++ b/src/ts/server/commands.ts
@@ -84,7 +84,7 @@ function adminModChat(names: string[], help: string, role: string, type: Message
 }
 
 export function parseSeason(value?: string): Season | undefined {
-    if (!value) return undefined;
+	if (!value) return undefined;
 	switch (value.toLowerCase()) {
 		case 'spring': return Season.Spring;
 		case 'summer': return Season.Summer;
@@ -95,7 +95,7 @@ export function parseSeason(value?: string): Season | undefined {
 }
 
 export function parseHoliday(value?: string): Holiday | undefined {
-    if (!value) return undefined;
+	if (!value) return undefined;
 	switch (value.toLowerCase()) {
 		case 'none': return Holiday.None;
 		case 'halloween': return Holiday.Halloween;

--- a/src/ts/server/config.ts
+++ b/src/ts/server/config.ts
@@ -29,6 +29,8 @@ export interface AppConfig {
 		trackingID: string;
 	};
 	assetsPath?: string;
+	season?: string;
+	holiday?: string;
 	oauth: { [key: string]: any };
 	servers: ServerConfig[];
 	facebookAppId?: string;

--- a/src/ts/server/serverActionsManager.ts
+++ b/src/ts/server/serverActionsManager.ts
@@ -19,7 +19,7 @@ import { PartyService } from './services/party';
 import { World, findClientByAccountId } from './world';
 import { log, chat } from './logger';
 import { createSay, LogChat } from './chat';
-import { createRunCommand, createCommands, getSpamCommandNames, parseSeason, parseHoliday } from './commands';
+import { createRunCommand, createCommands, getSpamCommandNames } from './commands';
 import { createIgnorePlayer, findClientByEntityId, createClientAndPony } from './playerUtils';
 import { createUpdateSettings } from './api/account';
 import { findAccountSafe, updateAccount, SupporterInvite, Account, IAccount, findFriendIds, findHideIds } from './db';

--- a/src/ts/server/serverActionsManager.ts
+++ b/src/ts/server/serverActionsManager.ts
@@ -19,7 +19,7 @@ import { PartyService } from './services/party';
 import { World, findClientByAccountId } from './world';
 import { log, chat } from './logger';
 import { createSay, LogChat } from './chat';
-import { createRunCommand, createCommands, getSpamCommandNames } from './commands';
+import { createRunCommand, createCommands, getSpamCommandNames, parseSeason, parseHoliday } from './commands';
 import { createIgnorePlayer, findClientByEntityId, createClientAndPony } from './playerUtils';
 import { createUpdateSettings } from './api/account';
 import { findAccountSafe, updateAccount, SupporterInvite, Account, IAccount, findFriendIds, findHideIds } from './db';
@@ -59,8 +59,8 @@ export function createServerActionsFactory(
 	const statesCounter = new CounterService<CharacterState>(10 * SECOND);
 	const logChatMessage: LogChat = (client, text, type, ignored, target) => chat(server, client, text, type, ignored, target);
 
-	world.season = SEASON;
-	world.holiday = HOLIDAY;
+	world.season = parseSeason(server.season) || SEASON;
+	world.holiday = parseHoliday(server.holiday) || HOLIDAY;
 
 	try {
 		const hidingData = fs.readFileSync(hidingDataPath(server.id), 'utf8');

--- a/src/ts/server/serverActionsManager.ts
+++ b/src/ts/server/serverActionsManager.ts
@@ -29,6 +29,7 @@ import { liveSettings } from './liveSettings';
 import { createIsSuspiciousMessage } from '../common/security';
 import { updateCharacterState } from './characterUtils';
 import { FriendsService } from './services/friends';
+import { config } from './config';
 
 async function refreshSettings(account: IAccount) {
 	const a = await Account.findOne({ _id: account._id }, 'settings').exec();
@@ -59,8 +60,8 @@ export function createServerActionsFactory(
 	const statesCounter = new CounterService<CharacterState>(10 * SECOND);
 	const logChatMessage: LogChat = (client, text, type, ignored, target) => chat(server, client, text, type, ignored, target);
 
-	world.season = parseSeason(server.season) || SEASON;
-	world.holiday = parseHoliday(server.holiday) || HOLIDAY;
+	world.season = parseSeason(server.season) || parseSeason(config.season) || SEASON;
+	world.holiday = parseHoliday(server.holiday) || parseHoliday(config.holiday) || HOLIDAY;
 
 	try {
 		const hidingData = fs.readFileSync(hidingDataPath(server.id), 'utf8');

--- a/src/ts/server/serverActionsManager.ts
+++ b/src/ts/server/serverActionsManager.ts
@@ -30,6 +30,7 @@ import { createIsSuspiciousMessage } from '../common/security';
 import { updateCharacterState } from './characterUtils';
 import { FriendsService } from './services/friends';
 import { config } from './config';
+import { parseSeason, parseHoliday } from '../common/utils';
 
 async function refreshSettings(account: IAccount) {
 	const a = await Account.findOne({ _id: account._id }, 'settings').exec();


### PR DESCRIPTION
Adds `season` and `holiday` configuration options, which can be used on a per-server basis to change the season and holiday on respective servers, as well as documentation for said configuration options.  The `parseSeason` and `parseHoliday` functions have also been updated to allow to them take a undefined value for a argument, and `parseHoliday` has additionally been updated to recognize all holidays listed under the `Holiday` enum.