### PR TITLE
Append trailing / to config.host if not present

### DIFF
--- a/src/ts/server/config.ts
+++ b/src/ts/server/config.ts
@@ -58,6 +58,11 @@ export const args = argv as AppArgs;
 export const { version, description }: AppPackage = require('../../../package.json');
 export const config: AppConfig = require('../../../config.json');
 
+// append / to host if the server op forgot it
+if (!config.host.endsWith('/')) {
+	config.host += '/';
+}
+
 const INSECURE_RANDOM_VALUES = [
 	'gfhfdshtrdhgedryhe4t3y5uwjthr',
 	'sdlfgihsdor8ghor8dgdrgdegrdg',


### PR DESCRIPTION
Fixes #54.

Minor QoL improvement for server operators. Should hopefully cut down on the number of reports we get related to this.

**To research:** Is there a better way? Should we otherwise normalize the URL passed to `host`?