### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/ci-config.json
+++ b/.github/ci-config.json
@@ -1,6 +1,6 @@
 {
 	"title": "pixel.horse CI",
-	"contactEmail": "noreply@pony.dev",
+	"contactEmail": "noreply@pixel.horse",
 	"port": 8090,
 	"adminPort": 8091,
 	"host": "http://localhost:8090/",

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '9.x'
       - name: install gulp
         run: bash .github/ci-install-gulp.sh
       - run: npm ci
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: '9.x'
       - name: install gulp
         run: bash .github/ci-install-gulp.sh
       - run: npm ci

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ jobs:
           node-version: '9.x'
       - name: install gulp
         run: bash .github/ci-install-gulp.sh
-      - run: npm ci
+      - run: npm install
       - name: write config.json
         run: cp .github/ci-config.json config.json
       - run: npm run lint
@@ -24,7 +24,7 @@ jobs:
           node-version: '9.x'
       - name: install gulp
         run: bash .github/ci-install-gulp.sh
-      - run: npm ci
+      - run: npm install
       - name: write config.json
         run: cp .github/ci-config.json config.json
       - run: npm run build


### PR DESCRIPTION
- Use Node 9.x (as the game's code is targeted at 9)
  - Use `npm install` over `npm ci` (since Node 9's included `npm` doesn't support `npm ci`)
  - **Discuss:** Should we continue to use Node 10? Builds work fine, but the current target version for the project is 9. I don't feel very comfortable using an EOL Node version as our target language version, but we want to ensure everything installs, builds, etc in our target environment.
- Use a more relevant snakeoil email
- Re-trigger Actions on this repository