### PR TITLE
Fix missing house tools action buttons

### DIFF
--- a/src/ts/client/buttonActions.ts
+++ b/src/ts/client/buttonActions.ts
@@ -118,6 +118,10 @@ const actionActions = [
 	actionButtonAction('drop', 'Drop item', Action.Drop),
 	actionButtonAction('drop-toy', 'Drop toy', Action.DropToy),
 	actionButtonAction('magic', 'Magic', Action.Magic),
+	actionButtonAction('switch-tool', 'Switch tool', Action.SwitchTool),
+	actionButtonAction('switch-entity', 'Switch item to place'),
+	actionButtonAction('switch-entity-rev', 'Switch item to place (reverse)'),
+	actionButtonAction('switch-tile', 'Switch tile to place'),
 	actionButtonAction('kiss', 'Kiss', Action.Kiss),
 ];
 


### PR DESCRIPTION
These were removed in the latest pt update, however since we are missing the new house actions tab these should be put back for now.