### PR TITLE
Remove need to pre-build hash for API versioning checks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,9 +20,6 @@ const remapIstanbul = require('remap-istanbul/lib/gulpRemapIstanbul');
 const spawn = require('child_process').spawn;
 const argv = require('yargs').argv;
 const config = require('./config.json');
-const stamp = Math.floor(Math.random() * 0xffffffff);
-const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-';
-const HASH = _.range(0, 10).map(() => chars[Math.floor(Math.random() * chars.length)]).join('');
 
 let development = true;
 
@@ -137,12 +134,6 @@ const shaders = cb => {
 		.map(([name, filePath]) => `export const ${name}Shader = \`${getShaderCode(filePath)}\`;`)
 		.join('\n\n');
 	fs.writeFile('src/ts/generated/shaders.ts', lintCode(code), 'utf8', cb);
-};
-
-const hash = cb => {
-	const code = `export const HASH = '${HASH}';\nexport const STAMP = ${stamp};`;
-	fs.writeFileSync('src/ts/generated/hash.ts', lintCode(code), 'utf8');
-	fs.writeFile('src/ts/generated/hash.json', JSON.stringify({ hash: HASH, stamp }), 'utf8', cb);
 };
 
 const rollbar = cb => {
@@ -283,7 +274,7 @@ const webpackAdmin = npmScript('webpack-admin');
 const sw = npmScript('sw');
 
 const assets = gulp.series(assetsCopy, assetsRev);
-const common = gulp.series(manifest, hash, rollbar, changelog, icons, shaders, assets, sassTasks);
+const common = gulp.series(manifest, rollbar, changelog, icons, shaders, assets, sassTasks);
 const covRemap = gulp.series(coverage, remap);
 
 const watch = cb => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pony-town",
-  "version": "0.53.2",
+  "version": "0.55.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8349,6 +8349,23 @@
             "once": "^1.3.1"
           }
         },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "optional": true
+        }
+      }
+    },
+    "git-describe": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.0.4.tgz",
+      "integrity": "sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==",
+      "requires": {
+        "lodash": "^4.17.11",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "frameguard": "^3.1.0",
     "fs-extra": "^8.1.0",
     "gif.js": "^0.2.0",
+    "git-describe": "^4.0.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.0",
     "gulp-cssnano": "^2.1.3",

--- a/src/ts/components/services/model.ts
+++ b/src/ts/components/services/model.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { merge } from 'lodash';
 import { Subject } from 'rxjs';
-import { HASH } from '../../generated/hash';
+
 import {
 	AccountData, UpdateAccountData, AccountSettings, GameStatus, SocialSiteInfo, PonyObject, JoinResponse,
 	OAuthProvider, EntitiesEditorInfo, FriendData, PalettePonyInfo, HiddenPlayer
@@ -485,7 +485,7 @@ export class Model {
 
 		const params = new HttpParams()
 			.set('t', (Date.now() % 0x10000).toString(16));
-		const headers = new HttpHeaders({ 'api-version': HASH, 'api-bid': this.storage.getItem('bid') || '-' });
+		const headers = new HttpHeaders({ 'api-version': process.env.GIT_HASH!, 'api-bid': this.storage.getItem('bid') || '-' });
 
 		return observableToPromise(this.http.post<T>(url, data, { params, headers }));
 	}

--- a/src/ts/components/services/rollbarErrorHandler.ts
+++ b/src/ts/components/services/rollbarErrorHandler.ts
@@ -1,7 +1,6 @@
 import { ErrorHandler, Injectable, Injector, InjectionToken } from '@angular/core';
 import * as Rollbar from 'rollbar';
 import { version } from '../../client/data';
-import { HASH } from '../../generated/hash';
 import { ROLLBAR_ENV, ROLLBAR_TOKEN } from '../../generated/rollbarConfig';
 import { rollbarCheckIgnore, isIgnoredError } from '../../common/rollbar';
 
@@ -23,7 +22,7 @@ const rollbarConfig = {
 			javascript: {
 				source_map_enabled: true,
 				guess_uncaught_frames: true,
-				code_version: HASH,
+				code_version: process.env.GIT_HASH,
 			},
 		},
 	},

--- a/src/ts/server/requestUtils.ts
+++ b/src/ts/server/requestUtils.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as moment from 'moment';
 import * as ExpressBrute from 'express-brute';
+import { gitDescribeSync } from 'git-describe';
 import { noop } from 'lodash';
-import { HASH } from '../generated/hash';
 import { isAdmin } from '../common/accountUtils';
 import { ACCOUNT_ERROR, VERSION_ERROR, OFFLINE_ERROR } from '../common/errors';
 import { logger } from './logger';
@@ -15,6 +15,7 @@ import { Settings, ServerConfig } from '../common/adminInterfaces';
 import { getIP } from './originUtils';
 import { IAccount } from './db';
 
+const GIT_HASH = gitDescribeSync(__dirname, { customArguments: ['--abbrev=40'] }).hash;
 const ROLLBAR_IP = '35.184.69.251';
 
 export const notFound: RequestHandler = (_, res) => {
@@ -49,7 +50,7 @@ export const blockMaps = (debug: boolean, local: boolean): RequestHandler => (re
 export const hash: RequestHandler = (req, res, next) => {
 	const apiVersion = req.get('api-version');
 
-	if (apiVersion !== HASH) {
+	if (apiVersion !== GIT_HASH) {
 		res.status(400).json({ error: VERSION_ERROR });
 	} else {
 		next(null);

--- a/src/ts/server/server.ts
+++ b/src/ts/server/server.ts
@@ -16,12 +16,12 @@ import { WebSocketServer } from 'clusterws-uws';
 import { compact, once } from 'lodash';
 import { copySync, removeSync, ensureDirSync } from 'fs-extra';
 import { createServerHost, createClientOptions, ServerOptions, ClientExtensions, Packet } from 'ag-sockets';
+import { gitDescribeSync } from 'git-describe';
 import { config, port, server, args, version } from './config';
 import { YEAR, WEEK } from '../common/constants';
 import { rollbarCheckIgnore } from '../common/rollbar';
 import { isBanned } from '../common/adminUtils';
 import { includes } from '../common/utils';
-import { STAMP } from '../generated/hash';
 import { ClientActions } from '../client/clientActions';
 import { ClientAdminActions } from '../client/clientAdminActions';
 import { ServerActions } from './serverActions';
@@ -59,6 +59,8 @@ import { InternalAdminApi } from './api/internal-admin';
 import { AdminService } from './services/adminService';
 import { createEndPoints } from './api/admin';
 import { World } from './world';
+
+const GIT_DISTANCE = gitDescribeSync(__dirname, { customArguments: ['--abbrev=40'] }).distance;
 
 function getServiceWorker() {
 	try {
@@ -207,7 +209,7 @@ const sessionMiddlewares = once(() => [createSession(), passport.initialize(), p
 const adminMiddlewares = once(() => [...sessionMiddlewares(), isAdmin(server)]);
 const socketOptionsBase: ServerOptions = {
 	ws: { Server: WebSocketServer },
-	hash: STAMP,
+	hash: GIT_DISTANCE,
 };
 
 initLogRequest(stats.logRequest);

--- a/src/typings/my.d.ts
+++ b/src/typings/my.d.ts
@@ -1,4 +1,5 @@
 /// <reference path="my/fix.d.ts" />
 /// <reference path="my/canvas.d.ts" />
+/// <reference path="my/git-describe.d.ts" />
 /// <reference path="my/node-async.d.ts" />
 /// <reference path="my/webgl-debug.d.ts" />

--- a/src/typings/my/git-describe.d.ts
+++ b/src/typings/my/git-describe.d.ts
@@ -1,0 +1,35 @@
+declare module 'git-describe' {
+	interface GitDescribeOpts {
+		dirtyMark?: string;
+		dirtySemver?: boolean;
+		longSemver?: boolean;
+		requireAnnotated?: boolean;
+		match?: string;
+		customArguments?: string[];
+	}
+
+	interface GitDescribeObj {
+		dirty: boolean;
+		hash: string;
+		distance: number;
+		tag: string;
+		/**
+		 * SemVer instance
+		 * @see https://github.com/npm/node-semver
+		 */
+		semver: object;
+		suffix: string;
+		raw: string;
+		semverString: string;
+	}
+
+	export function gitDescribeSync(
+		directory: string,
+		options?: GitDescribeOpts,
+		cb?: () => GitDescribeObj
+	): GitDescribeObj;
+	export function gitDescribeSync(
+		directory: string,
+		options?: GitDescribeOpts
+	): GitDescribeObj;
+}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,3 +1,4 @@
+const { gitDescribeSync } = require('git-describe');
 const webpack = require('webpack');
 const path = require('path');
 
@@ -65,6 +66,9 @@ module.exports = {
 		],
 	},
 	plugins: [
+		new webpack.DefinePlugin({
+			GIT_HASH: JSON.stringify(gitDescribeSync(__dirname, { customArguments: ['--abbrev=40'] }).hash)
+		}),
 		new webpack.ContextReplacementPlugin(
 			/\@angular(\\|\/)core(\\|\/)fesm5/,
 			path.resolve(__dirname, 'src', 'ts'),


### PR DESCRIPTION
This replaces the randomly generated hash with the latest Git hash from the repo, live on the server or passed through as a Webpack env var on the client.

Note that this may not be ideal because it requires (a) `git` to be installed on the server or the Webpack machine, and (b) requires the server to be run from at least a shallow clone of the git repo so it can retrieve the Git hash.